### PR TITLE
Remove requirement of CUDA and Jetson Inference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,18 @@
 cmake_minimum_required(VERSION 3.15)
 project(mirage)
 
+# Build options
+option(USE_JETSON_INFERENCE "Enable Jetson Inference support" OFF)
+option(USE_CUDA "Enable CUDA support" OFF)
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose build type: Debug or Release")
+
 # If the policy exists in your CMake version, set it to NEW
 if(POLICY CMP0072)
     cmake_policy(SET CMP0072 NEW)
 endif()
 
-# Define the version number in the header file directly
+# Version and Git SHA
 set(VERSION_NUMBER "1.0.0")
-
-# Try to get the current Git SHA
 execute_process(
     COMMAND git rev-parse --short HEAD
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -18,13 +21,9 @@ execute_process(
     ERROR_QUIET
     RESULT_VARIABLE GIT_SHA_RESULT
 )
-
-# Check if the command was successful
 if(NOT GIT_SHA_RESULT EQUAL 0)
     set(GIT_SHA "unknown")
 endif()
-
-# Pass the Git SHA to the compiler
 add_definitions(-DGIT_SHA=\"${GIT_SHA}\")
 
 # Set source files
@@ -46,77 +45,99 @@ set(SOURCE_FILES
 
 # Set C compiler and flags
 set(CMAKE_C_COMPILER gcc)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Werror -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-variable")
+set(CMAKE_CXX_COMPILER g++)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wno-error=unused-but-set-variable -Wno-error=unused-function -Wno-error=unused-variable")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS}")
 
 # Set include directories
-include_directories(/usr/include/vorbis /usr/local/include/vorbis /usr/local/include/jetson-inference /usr/src/jetson_multimedia_api/include)
+include_directories(/usr/include/vorbis /usr/local/include/vorbis)
+
+# Conditional Jetson includes
+if(USE_JETSON_INFERENCE)
+    include_directories(/usr/local/include/jetson-inference /usr/src/jetson_multimedia_api/include)
+    add_definitions(-DUSE_JETSON_INFERENCE)
+endif()
 
 # Find required packages
 find_package(PkgConfig REQUIRED)
 
+# Audio dependencies
 pkg_check_modules(VORBISFILE REQUIRED vorbisfile)
 include_directories(${VORBISFILE_INCLUDE_DIRS})
-
 pkg_check_modules(ALSA REQUIRED alsa)
 include_directories(${ALSA_INCLUDE_DIRS})
 
+# Core dependencies
 pkg_check_modules(JSONC REQUIRED json-c)
 include_directories(${JSONC_INCLUDE_DIRS})
-
 pkg_check_modules(SDL2 REQUIRED sdl2)
 include_directories(${SDL2_INCLUDE_DIRS})
-
 find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIRS})
 
+# Gstreamer
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0 gstreamer-app-1.0)
 include_directories(${GSTREAMER_INCLUDE_DIRS})
-
 pkg_check_modules(GLIB REQUIRED glib-2.0)
 include_directories(${GLIB_INCLUDE_DIRS})
 
+# Communications
 pkg_check_modules(MOSQUITTO REQUIRED libmosquitto)
 include_directories(${MOSQUITTO_INCLUDE_DIRS})
 
-# Find the OpenGL package
+# OpenGL Support
 find_package(OpenGL REQUIRED)
-
-# If you also need GLEW (for example), find it here
 find_package(GLEW REQUIRED)
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(CUDA REQUIRED cuda-12.2 cudart-12.2)
-include_directories(${CUDA_INCLUDE_DIRS})
-link_directories(${CUDA_LIBRARY_DIRS})
+# Optional CUDA support
+if(USE_CUDA)
+    pkg_check_modules(CUDA REQUIRED cuda-12.2 cudart-12.2)
+    include_directories(${CUDA_INCLUDE_DIRS})
+    link_directories(${CUDA_LIBRARY_DIRS})
+endif()
 
 # Set libraries
-set(LIBRARIES 
+set(LIBRARIES
+  # Audio
   ${VORBISFILE_LIBRARIES}
   ${ALSA_LIBRARIES}
+
+  # Core
   ${JSONC_LIBRARIES}
   ${SDL2_LIBRARIES}
   ${CURL_LIBRARIES}
-  ${GSTREAMER_LIBRARIES}
-  ${GLIB_LIBRARIES}
-  ${MOSQUITTO_LIBRARIES}
-  ${OPENGL_LIBRARIES}
-  ${GLEW_LIBRARIES}
-  gd
-  ${CUDA_LIBRARIES}
   SDL2_image
   SDL2_ttf
-  jetson-inference
-  jetson-utils
+
+  # Graphics and Video
+  ${GSTREAMER_LIBRARIES}
+  ${GLIB_LIBRARIES}
+  ${OPENGL_LIBRARIES}
+  ${GLEW_LIBRARIES}
   X11
+  gd
+
+  # Communications
+  ${MOSQUITTO_LIBRARIES}
+
+  # System
   pthread
   rt
   m
   stdc++
 )
 
-link_directories(/usr/lib/aarch64-linux-gnu/tegra)
+# Optional libraries
+if(USE_CUDA)
+    list(APPEND LIBRARIES ${CUDA_LIBRARIES})
+endif()
 
-# Create executable
+if(USE_JETSON_INFERENCE)
+    list(APPEND LIBRARIES jetson-inference jetson-utils)
+    link_directories(/usr/lib/aarch64-linux-gnu/tegra)
+endif()
+
+# Targets
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} ${LIBRARIES})
 
@@ -126,3 +147,4 @@ add_custom_target(
   COMMAND indent -linux -nut -i3 -l100 ${SOURCE_FILES}
 )
 
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/detect.cpp
+++ b/detect.cpp
@@ -4,12 +4,15 @@
 #include <unistd.h>
 #include <semaphore.h>
 
+#ifdef USE_JETSON_INFERENCE
 #include <detectNet.h>
+#endif
 #include "detect.h"
 
 /* Initialize detection struct. */
 int init_detect(detect_net * new_detect, int argc, char **argv, int width, int height)
 {
+#ifdef USE_JETSON_INFERENCE
    detectNet *net = NULL;
 
    /* Create detectNet Instance */
@@ -36,6 +39,9 @@ int init_detect(detect_net * new_detect, int argc, char **argv, int width, int h
    new_detect->l_height = height;
 
    return 0;
+#else
+   return 1;
+#endif
 }
 
 /* Detect objects in the given image. */
@@ -45,6 +51,7 @@ int init_detect(detect_net * new_detect, int argc, char **argv, int width, int h
  */
 int detect_image(detect_net * new_detect, void *image, detect * my_detects, int max_detections)
 {
+#ifdef USE_JETSON_INFERENCE
    int n = 0;
    int a = 0;
    detectNet *net = (detectNet *) new_detect->detectNet_net;
@@ -91,11 +98,15 @@ int detect_image(detect_net * new_detect, void *image, detect * my_detects, int 
    //cudaMemcpy(image, new_detect->d_image, new_detect->l_width * new_detect->l_height * sizeof(uchar4), cudaMemcpyDeviceToHost);
 
    return numDetections;
+#else
+   return 0;
+#endif
 }
 
 /* Clean up detection struct. */
 void free_detect(detect_net * new_detect)
 {
+#ifdef USE_JETSON_INFERENCE
    detectNet *net = (detectNet *) new_detect->detectNet_net;
 
    cudaFree(new_detect->d_image);
@@ -105,4 +116,5 @@ void free_detect(detect_net * new_detect)
    new_detect->l_height = 0;
 
    SAFE_DELETE(net);
+#endif
 }

--- a/mirage.c
+++ b/mirage.c
@@ -91,8 +91,10 @@
 #include <mosquitto.h>
 
 /* NVIDIA/CUDA */
+#ifdef USE_CUDA
 #include <cuda_runtime.h>
 //#include <nvbuf_utils.h>
+#endif
 
 #include <GL/glew.h>
 #include <stdbool.h>
@@ -2293,7 +2295,7 @@ int main(int argc, char **argv)
       pthread_mutex_lock(&v_mutex);
       if (video_posted) {
          if (detect_enabled) {
-#ifdef OD_PROPER_WAIT
+#if defined(OD_PROPER_WAIT) && defined(USE_CUDA)
             oddataL.pix_data = mapL[buffer_num].data;
             oddataL.eye = 0;
             cudaMemcpy(oddataL.detect_obj.d_image, oddataL.pix_data,


### PR DESCRIPTION
- Inference is not currently being used until I rework object detection.
- CUDA is only needed for inference and an optional compile time setting I'm not currently using.
- The goal is both less requirements and cross-platform.